### PR TITLE
fix: replace hardcoded JWT/session/CSRF/DB/MinIO/Redis secrets with env vars

### DIFF
--- a/bizdemo/hertz_jwt/biz/mw/jwt.go
+++ b/bizdemo/hertz_jwt/biz/mw/jwt.go
@@ -19,7 +19,9 @@ package mw
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/cloudwego/hertz-examples/bizdemo/hertz_jwt/biz/dal/mysql"
@@ -36,11 +38,20 @@ var (
 	IdentityKey   = "identity"
 )
 
+func getJWTKey() []byte {
+	key := os.Getenv("JWT_SECRET_KEY")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET_KEY is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
+	}
+	return []byte(key)
+}
+
 func InitJwt() {
 	var err error
 	JwtMiddleware, err = jwt.New(&jwt.HertzJWTMiddleware{
 		Realm:         "test zone",
-		Key:           []byte("secret key"),
+		Key:           getJWTKey(),
 		Timeout:       time.Hour,
 		MaxRefresh:    time.Hour,
 		TokenLookup:   "header: Authorization, query: token, cookie: jwt",

--- a/bizdemo/hertz_session/biz/dal/mysql/init.go
+++ b/bizdemo/hertz_session/biz/dal/mysql/init.go
@@ -27,7 +27,7 @@ var DB *gorm.DB
 
 func Init() {
 	var err error
-	DB, err = gorm.Open(mysql.Open(consts.MySQLDefaultDSN), &gorm.Config{
+	DB, err = gorm.Open(mysql.Open(consts.GetMySQLDSN()), &gorm.Config{
 		SkipDefaultTransaction: true,
 		PrepareStmt:            true,
 		Logger:                 logger.Default.LogMode(logger.Info),

--- a/bizdemo/hertz_session/biz/mw/csrf.go
+++ b/bizdemo/hertz_session/biz/mw/csrf.go
@@ -30,7 +30,7 @@ import (
 
 func InitCSRF(h *server.Hertz) {
 	h.Use(csrf.New(
-		csrf.WithSecret(consts.CSRFSecretKey),
+		csrf.WithSecret(consts.GetCSRFSecret()),
 		csrf.WithKeyLookUp(consts.CSRFKeyLookUp),
 		csrf.WithNext(utils.IsLogout),
 		csrf.WithErrorFunc(func(ctx context.Context, c *app.RequestContext) {

--- a/bizdemo/hertz_session/biz/mw/session.go
+++ b/bizdemo/hertz_session/biz/mw/session.go
@@ -24,7 +24,7 @@ import (
 )
 
 func InitSession(h *server.Hertz) {
-	store, err := redis.NewStore(consts.MaxIdleNum, consts.TCP, consts.RedisAddr, consts.RedisPasswd, []byte(consts.SessionSecretKey))
+	store, err := redis.NewStore(consts.MaxIdleNum, consts.TCP, consts.RedisAddr, consts.RedisPasswd, consts.GetSessionSecret())
 	if err != nil {
 		panic(err)
 	}

--- a/bizdemo/hertz_session/pkg/consts/consts.go
+++ b/bizdemo/hertz_session/pkg/consts/consts.go
@@ -16,19 +16,51 @@
 
 package consts
 
+import (
+	"fmt"
+	"os"
+)
+
+// getSessionSecret retrieves the session secret from env, with fatal exit if unset.
+func GetSessionSecret() []byte {
+	key := os.Getenv("SESSION_SECRET")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: SESSION_SECRET is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
+	}
+	return []byte(key)
+}
+
+// GetCSRFSecret retrieves the CSRF secret from env, with fatal exit if unset.
+func GetCSRFSecret() string {
+	key := os.Getenv("CSRF_SECRET")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: CSRF_SECRET is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
+	}
+	return key
+}
+
+// GetMySQLDSN retrieves the MySQL DSN from env, with fatal exit if unset.
+func GetMySQLDSN() string {
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		fmt.Fprintf(os.Stderr, "fatal: DB_DSN is not set\n")
+		os.Exit(1)
+	}
+	return dsn
+}
+
 // constants
 const (
-	TCP              = "tcp"
-	UserTableName    = "users"
-	RedisAddr        = "127.0.0.1:6379"
-	MaxIdleNum       = 10
-	RedisPasswd      = ""
-	SessionSecretKey = "session-secret"
-	CSRFSecretKey    = "csrf-secret"
-	CSRFKeyLookUp    = "form:csrf"
-	Username         = "username"
-	HertzSession     = "HERTZ-SESSION"
-	MySQLDefaultDSN  = "gorm:gorm@tcp(127.0.0.1:3306)/gorm?charset=utf8&parseTime=True&loc=Local"
+	TCP           = "tcp"
+	UserTableName = "users"
+	RedisAddr     = "127.0.0.1:6379"
+	MaxIdleNum    = 10
+	RedisPasswd   = ""
+	CSRFKeyLookUp = "form:csrf"
+	Username      = "username"
+	HertzSession  = "HERTZ-SESSION"
 )
 
 // error msg

--- a/bizdemo/tiktok_demo/biz/dal/db/init.go
+++ b/bizdemo/tiktok_demo/biz/dal/db/init.go
@@ -29,7 +29,7 @@ var DB *gorm.DB
 // Init init DB
 func Init() {
 	var err error
-	DB, err = gorm.Open(mysql.Open(constants.MySQLDefaultDSN),
+	DB, err = gorm.Open(mysql.Open(constants.GetMySQLDSN()),
 		&gorm.Config{
 			PrepareStmt:            true,
 			SkipDefaultTransaction: true,

--- a/bizdemo/tiktok_demo/biz/mw/jwt/jwt.go
+++ b/bizdemo/tiktok_demo/biz/mw/jwt/jwt.go
@@ -18,6 +18,8 @@ package jwt
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
@@ -37,9 +39,18 @@ var (
 	identity      = "user_id"
 )
 
+func getJWTKey() []byte {
+	key := os.Getenv("JWT_SECRET_KEY")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: JWT_SECRET_KEY is not set. Generate one with: openssl rand -base64 32\n")
+		os.Exit(1)
+	}
+	return []byte(key)
+}
+
 func Init() {
 	JwtMiddleware, _ = jwt.New(&jwt.HertzJWTMiddleware{
-		Key:         []byte("tiktok secret key"),
+		Key:         getJWTKey(),
 		TokenLookup: "query:token,form:token",
 		Timeout:     24 * time.Hour,
 		IdentityKey: identity,

--- a/bizdemo/tiktok_demo/biz/mw/minio/minio.go
+++ b/bizdemo/tiktok_demo/biz/mw/minio/minio.go
@@ -83,8 +83,8 @@ func PutToBucketByFilePath(ctx context.Context, bucketName, filename, filepath s
 
 func Init() {
 	ctx := context.Background()
-	Client, err = minio.New(constants.MinioEndPoint, &minio.Options{
-		Creds:  credentials.NewStaticV4(constants.MinioAccessKeyID, constants.MinioSecretAccessKey, ""),
+	Client, err = minio.New(constants.GetMinioEndpoint(), &minio.Options{
+		Creds:  credentials.NewStaticV4(constants.GetMinioAccessKeyID(), constants.GetMinioSecretAccessKey(), ""),
 		Secure: constants.MiniouseSSL,
 	})
 	if err != nil {

--- a/bizdemo/tiktok_demo/biz/mw/redis/redis.go
+++ b/bizdemo/tiktok_demo/biz/mw/redis/redis.go
@@ -32,13 +32,13 @@ var (
 
 func InitRedis() {
 	rdbFollows = redis.NewClient(&redis.Options{
-		Addr:     constants.RedisAddr,
-		Password: constants.RedisPassword,
+		Addr:     constants.GetRedisAddr(),
+		Password: constants.GetRedisPassword(),
 		DB:       0,
 	})
 	rdbFavorite = redis.NewClient(&redis.Options{
-		Addr:     constants.RedisAddr,
-		Password: constants.RedisPassword,
+		Addr:     constants.GetRedisAddr(),
+		Password: constants.GetRedisPassword(),
 		DB:       1,
 	})
 }

--- a/bizdemo/tiktok_demo/pkg/constants/constant.go
+++ b/bizdemo/tiktok_demo/pkg/constants/constant.go
@@ -16,17 +16,69 @@
 
 package constants
 
+import (
+	"fmt"
+	"os"
+)
+
+// GetMySQLDSN retrieves the MySQL DSN from env, with fatal exit if unset.
+func GetMySQLDSN() string {
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		fmt.Fprintf(os.Stderr, "fatal: DB_DSN is not set\n")
+		os.Exit(1)
+	}
+	return dsn
+}
+
+// GetMinioEndpoint retrieves the MinIO endpoint from env, with fatal exit if unset.
+func GetMinioEndpoint() string {
+	ep := os.Getenv("MINIO_ENDPOINT")
+	if ep == "" {
+		fmt.Fprintf(os.Stderr, "fatal: MINIO_ENDPOINT is not set\n")
+		os.Exit(1)
+	}
+	return ep
+}
+
+// GetMinioAccessKeyID retrieves the MinIO access key from env, with fatal exit if unset.
+func GetMinioAccessKeyID() string {
+	key := os.Getenv("MINIO_ACCESS_KEY_ID")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: MINIO_ACCESS_KEY_ID is not set\n")
+		os.Exit(1)
+	}
+	return key
+}
+
+// GetMinioSecretAccessKey retrieves the MinIO secret key from env, with fatal exit if unset.
+func GetMinioSecretAccessKey() string {
+	key := os.Getenv("MINIO_SECRET_ACCESS_KEY")
+	if key == "" {
+		fmt.Fprintf(os.Stderr, "fatal: MINIO_SECRET_ACCESS_KEY is not set\n")
+		os.Exit(1)
+	}
+	return key
+}
+
+// GetRedisAddr retrieves the Redis address from env, with fatal exit if unset.
+func GetRedisAddr() string {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		fmt.Fprintf(os.Stderr, "fatal: REDIS_ADDR is not set\n")
+		os.Exit(1)
+	}
+	return addr
+}
+
+// GetRedisPassword retrieves the Redis password from env, with fatal exit if unset.
+func GetRedisPassword() string {
+	return os.Getenv("REDIS_PASSWORD")
+}
+
 // connection information
 const (
-	MySQLDefaultDSN = "douyin:douyin123@tcp(127.0.0.1:18000)/douyin?charset=utf8&parseTime=True&loc=Local"
-
-	MinioEndPoint        = "localhost:18001"
-	MinioAccessKeyID     = "douyin"
-	MinioSecretAccessKey = "douyin123"
-	MiniouseSSL          = false
-
-	RedisAddr     = "localhost:18003"
-	RedisPassword = "douyin123"
+	MiniouseSSL = false
 )
 
 // constants in the project


### PR DESCRIPTION
## Summary

Fix CWE-798 hardcoded credentials across 3 demo applications in the hertz-examples repository:

### 1. hertz_jwt — hardcoded JWT signing key (CWE-798)
**bizdemo/hertz_jwt/biz/mw/jwt.go:43:**
```
// Before:
Key: []byte("secret key"),
// After:
Key: getJWTKey(),  // reads JWT_SECRET_KEY from env, fatal if unset
```
Any attacker who reads the source can forge valid JWT tokens with "secret key" and bypass authentication.

### 2. hertz_session — hardcoded session/CSRF secrets + DB credentials (CWE-798)
**bizdemo/hertz_session/pkg/consts/consts.go:26-31:**
```
// Before:
SessionSecretKey = "session-secret"
CSRFSecretKey    = "csrf-secret"
MySQLDefaultDSN  = "gorm:gorm@tcp(127.0.0.1:3306)/gorm?..."
// After:
GetSessionSecret() / GetCSRFSecret() / GetMySQLDSN()  // reads from env vars
```
Session secret "session-secret" allows forging session cookies (admin access). Database credentials "gorm:gorm" allow direct database access.

### 3. tiktok_demo — hardcoded DB/MinIO/Redis credentials (CWE-798)
**bizdemo/tiktok_demo/pkg/constants/constant.go:21-29:**
```
// Before:
MySQLDefaultDSN     = "douyin:douyin123@tcp(127.0.0.1:18000)/douyin?..."
MinioAccessKeyID     = "douyin"
MinioSecretAccessKey = "douyin123"
RedisPassword        = "douyin123"
// After: All replaced with env-var functions (fatal if unset)
```
Database, MinIO object storage, and Redis credentials are all publicly readable.

## Relationship to other CloudWeGo findings

This is the same hardcoded credential pattern found across ALL CloudWeGo demo repositories:

| PR | Repository | Framework | Pattern |
|---|-----------|-----------|---------|
| This PR | hertz-examples | **Hertz** | JWT "secret key" + session + DB + MinIO + Redis |
| [#195](https://github.com/cloudwego/kitex-examples/pull/195) | kitex-examples | **Kitex** | JWT "secret key" + DB "gorm:gorm" |
| [#98](https://github.com/cloudwego/biz-demo/pull/98) | biz-demo | **Hertz** | JWT "secret key" + DB "gorm:gorm" |

The JWT signing key `"secret key"` is identical across all three repositories (hertz-examples/hertz_jwt, kitex-examples/easy_note, biz-demo/easy_note), indicating a systemic copy-paste pattern in CloudWeGo's official examples.

## Verification

```
cd bizdemo/hertz_jwt && go build ./...   # passes
cd bizdemo/hertz_session && go build ./... # passes
```
